### PR TITLE
attempt to fix alleluia

### DIFF
--- a/bin/data/lem_ext.fr
+++ b/bin/data/lem_ext.fr
@@ -2443,8 +2443,8 @@ allegorice:allégoriquement
 allegoricus:allégorique, symbolique
 allegorista:interprète des allégories
 allegorizo:employer l'allégorie
-alleluia:du mot hébreu הַלְּלוּיָהּ signifiant / louez Dieu
-alleluiaticus:qui loue Dieu
+alleluja:du mot hébreu הַלְּלוּיָהּ signifiant / louez Dieu
+allelujaticus:qui loue Dieu
 allenimentum:adoucissement, manière de calmer
 allex:préparation culinaire à base de poisson / poisson
 allex2:gros orteil
@@ -24030,8 +24030,6 @@ Halius:nom d'homme
 Halizones:Halizons [peuple de la Bithynie ou du Pont]
 hallec:préparation culinaire à base de poisson / poisson
 hallecatus:assaisonné de allec
-halleluia:du mot hébreu הַלְּלוּיָהּ signifiant : louez Dieu
-hallelujah:alleluia (mot hébreu signifiant : louez Dieu).
 hallex:préparation culinaire à base de poisson / poisson
 hallex2:gros orteil
 hallucinatio:méprise, hallucination

--- a/bin/data/lem_ext.la
+++ b/bin/data/lem_ext.la
@@ -2472,8 +2472,8 @@ allēgŏrĭcē=āllēgŏrĭcē|adv|||adv.
 allēgŏrĭcus=āllēgŏrĭcus|doctus|||a, um
 allēgŏrista=āllēgŏrīsta|uita|||ae, m.
 allēgŏrīzo=āllēgŏrīzo|amo|||āvi, āre, intr.
-āllēlūia=āllēlūĭa|adv|||interj.
-allēlūiāticus=āllēlūĭāticus|doctus|||a, um
+āllēlūjă|adv|||interj.
+āllēlūjāticus|doctus|||a, um
 allēnīmentum=āllēnīmēntum|templum|||i, n.
 allex=āllēx|corpus|āllēc||ēcis, n.
 allex2=āllēx|miles|āllĭc||ĭcis, m.
@@ -2744,7 +2744,7 @@ ambestrix=āmbēstrīx|miles|āmbēstrīc||īcis, f.
 ambēsus=āmbēsus|doctus|||a, um
 Ambĭānī=Āmbĭānī|lupus|||orum, m.
 Ambibarĭī=Āmbibarĭī|lupus|||orum, m.
-ambĭdens=āmbĭdēns|ciuis|āmbĭdēnt||entis, 
+ambĭdens=āmbĭdēns|ciuis|āmbĭdēnt||entis,
 ambĭdextĕr=āmbĭdēxtĕr|pulcher|āmbĭdēxtr||tra, trum
 ambiegna=āmbĭēgna|uita|||ae, f.
 ambĭendus=āmbĭēndus|doctus|||a, um
@@ -4806,7 +4806,7 @@ armārĭŏlum=ārmārĭŏlum|templum|||i, n.
 armāti=ārmāti|liberi|||orum, m.
 armātĭo=ārmātĭo|miles|ārmātĭōn||ōnis, f.
 armātŏr=ārmātŏr|miles|ārmātōr||ōris, m.
-armātrīx=ārmātrīx|miles|ārmātrīc||īcis, 
+armātrīx=ārmātrīx|miles|ārmātrīc||īcis,
 armātŭs2=ārmātŭs|manus|||us, m.
 Armĕnĭăca=Ārmĕnĭăca|roma|||ae, f.
 Armĕnĭăcum=Ārmĕnĭăcum|templum|||i, n.
@@ -11522,7 +11522,7 @@ cŏhortātus=cŏhōrtātus|doctus|||a, um
 cŏhortĭcŭla=cŏhōrtĭcŭla|uita|||ae, f.
 cŏhorto=cŏhōrto|amo|||āre, 1
 cŏhospĕs=cŏhōspĕs|miles|cŏhōspĭt||ĭtis, m.
-cŏhospĭtans=cŏhōspĭtāns|ciuis|cŏhōspĭtānt||antis, 
+cŏhospĭtans=cŏhōspĭtāns|ciuis|cŏhōspĭtānt||antis,
 cŏhum|templum|||i, n.
 cŏhūmĭdo|amo|||āre
 cŏhus|lupus|||i, m.
@@ -14808,7 +14808,7 @@ cuppēdĭnārĭus=cūppēdĭnārĭus|aureus|||a, um
 cuppēdĭnārĭus2=cūppēdĭnārĭus|filius|||ii, m.
 cuppēdĭum=cūppēdĭum|templum|||ii, n.
 cuppēdo=cūppēdo|miles|cūppēdĭn||ĭnis, f.
-cuppēs=cūppēs|miles|cūppĕd||ĕdis, 
+cuppēs=cūppēs|miles|cūppĕd||ĕdis,
 Cūpra|roma|||ae, f.
 Cūprenses=Cūprēnses|ciuis|Cūprēns||ium, m.
 cū̆pressētum=cū̆prēssētum|templum|||i, n.
@@ -15358,7 +15358,7 @@ dēbātŭo|lego|||ĕre
 dēbellātĭo=dēbēllātĭo|miles|dēbēllātĭōn||ōnis, f.
 dēbellātŏr=dēbēllātŏr|miles|dēbēllātōr||ōris, m.
 dēbellātrix=dēbēllātrīx|miles|dēbēllātrīc||īcis, f.
-dēbēns|ciuis|dēbēnt||entis, 
+dēbēns|ciuis|dēbēnt||entis,
 dēbĭbo|lego|||ĕre
 dēbĭl|diues|dēbĭl||is
 dēbĭlĭtātē|adv|||adv.
@@ -16977,7 +16977,7 @@ diffāmātus=dīffāmātus|doctus|||a, um
 diffāmĭa=dīffāmĭa|uita|||ae, f.
 diffarrĕātĭo=dīffārrĕātĭo|miles|dīffārrĕātĭōn||ōnis, f.
 diffatīgo=dīffatīgo|amo|||āre
-diffĕrens=dīffĕrēns|ciuis|dīffĕrēnt||entis, 
+diffĕrens=dīffĕrēns|ciuis|dīffĕrēnt||entis,
 diffĕrentĕr=dīffĕrēntĕr|adv|||adv.
 diffĕrĭtās=dīffĕrĭtās|miles|dīffĕrĭtāt||ātis, f.
 differtus=dīffērtus|doctus|||a, um
@@ -19547,7 +19547,7 @@ erctum=ērctum|templum|||i, n.
 ēreptŏr=ērēptŏr|miles|ērēptōr||ōris, m.
 ēreptōrĭus=ērēptōrĭus|aureus|||a, um
 ēreptus=ērēptus|doctus|||a, um
-ērēs|miles|ērēd||ēdis, 
+ērēs|miles|ērēd||ēdis,
 Ērētīnus|doctus|||a, um
 Ĕrĕtrĭa|roma|||ae, f.
 Ĕrĕtrĭăci|liberi|||orum, m.
@@ -22330,7 +22330,7 @@ fosso=fōsso|amo|||āvi, ātum, 1
 fossŏr=fōssŏr|miles|fōssōr||ōris, m.
 fossōrĭum=fōssōrĭum|templum|||ii, n.
 fossōrĭus=fōssōrĭus|aureus|||a, um
-fossrīx=fōssrīx|miles|fōssrīc||īcis, 
+fossrīx=fōssrīx|miles|fōssrīc||īcis,
 fossŭla=fōssŭla|uita|||ae, f.
 fossūra=fōssūra|uita|||ae, f.
 fossus=fōssus|doctus|||a, um
@@ -24289,8 +24289,8 @@ Hălĭus|filius|||ii, m.
 Hălizones=Hălīzones|opes|Hălīzon||um, m.
 hallēc=hāllēc|corpus|hāllēc||ēcis, n.
 hallēcatus=hāllēcatus|doctus|||a, um
-hallēlūiā=hāllēlūĭā|adv|||interj.
-hallĕlūjah=hāllĕlūjah|adv|||interj.
+hāllēlūjă|adv|||cf. alleluia
+hāllēlūjăh|adv|||cf. alleluia
 hallex=hāllēx|corpus|hāllēc||ēcis, n.
 hallex2=hāllēx|miles|hāllĭc||ĭcis, m.
 hallūcĭnātĭo=hāllūcĭnātĭo|miles|hāllūcĭnātĭōn||ōnis, f.
@@ -29284,7 +29284,7 @@ irreptĭo=īrrēptĭo|miles|īrrēptĭōn||ōnis, f.
 irrepto=īrrēpto|amo|||āre
 irreptŏr=īrrēptŏr|miles|īrrēptōr||ōris, m.
 irrĕquĭēbĭlis=īrrĕqụĭēbĭlis|fortis|īrrĕqụĭēbĭl||e
-irrĕquĭēs=īrrĕqụĭēs|miles|īrrĕqụĭēt||ētis, 
+irrĕquĭēs=īrrĕqụĭēs|miles|īrrĕqụĭēt||ētis,
 irrĕquĭētus=īrrĕqụĭētus|doctus|||a, um
 irrĕquīsītus=īrrĕqụīsītus|doctus|||a, um
 irrĕsectus=īrrĕsēctus|doctus|||a, um
@@ -29944,7 +29944,7 @@ lactārĭus2=lāctārĭus|filius|||i, m.
 lactātĭo=lāctātĭo|miles|lāctātĭōn||ōnis, f.
 lactātum=lāctātum|templum|||i, n.
 lactĕ=lāctĕ|mare|lāct||is, n.
-lactēns=lāctēns|ciuis|lāctēnt||entis, 
+lactēns=lāctēns|ciuis|lāctēnt||entis,
 lactentĭa=lāctēntĭa|moenia|lāctēnt||ium, n.
 lactĕŏlus=lāctĕŏlus|doctus|||a, um
 lactēris=lāctēris|miles|lāctērĭd||ĭdis, f.
@@ -31764,7 +31764,7 @@ lūcīnĭum|templum|||ii, n.
 lūcīnus|doctus|||a, um
 Lūcĭŏla|roma|||ae, f.
 Lūcĭŏlus|lupus|||i, m.
-lūcĭpărens=lūcĭpărēns|ciuis|lūcĭpărēnt||entis, 
+lūcĭpărens=lūcĭpărēns|ciuis|lūcĭpărēnt||entis,
 lūcĭpĕtā|uita|||ae, f.
 lūcĭpĕtus|doctus|||a, um
 Lūcĭpōr|miles|Lūcĭpōr||ōris, m.
@@ -33920,7 +33920,7 @@ mĭnābĭlĭtĕr|adv|||adv.
 mĭnācĭae=mĭnācĭāe|epulae|||arum, f.
 Mīnaei=Mīnāei|liberi|||orum, m.
 Mĭnaeus=Mĭnāeus|doctus|||a, um
-mĭnāns|ciuis|mĭnānt||antis, 
+mĭnāns|ciuis|mĭnānt||antis,
 mĭnātĭo|miles|mĭnātĭōn||ōnis, f.
 mĭnātŏr|miles|mĭnātōr||ōris, m.
 mĭnātōrĭus|aureus|||a, um
@@ -41503,7 +41503,7 @@ pĭcārĭa|uita|||ae, f.
 pīcātĭo|miles|pīcātĭōn||ōnis, f.
 pĭcātus|doctus|||a, um
 pĭcĕa|uita|||ae, f.
-Pīcens=Pīcēns|ciuis|Pīcēnt||entis, 
+Pīcens=Pīcēns|ciuis|Pīcēnt||entis,
 Pīcentes=Pīcēntes|ciuis|Pīcēnt||ium, m.
 Pīcentĭa=Pīcēntĭa|roma|||ae, f.
 Pīcentīnus=Pīcēntīnus|doctus|||a, um
@@ -44750,7 +44750,7 @@ pūgĭuncŭlus=pūgĭūncŭlus|lupus|||i, m.
 pūgnābĭlĭs|fortis|pūgnābĭl||e
 pugnācĭtās=pūgnācĭtās|miles|pūgnācĭtāt||ātis, f.
 pugnācŭlum=pūgnācŭlum|templum|||i, n.
-pugnans=pūgnāns|ciuis|pūgnānt||antis, 
+pugnans=pūgnāns|ciuis|pūgnānt||antis,
 pūgnantĭa=pūgnāntĭa|moenia|pūgnānt||ium, n.
 pugnātŏr=pūgnātŏr|miles|pūgnātōr||ōris, m.
 pugnātōrĭus=pūgnātōrĭus|aureus|||a, um
@@ -47713,7 +47713,7 @@ sălictārĭus=sălīctārĭus|aureus|||a, um
 sălictārĭus2=sălīctārĭus|filius|||ii, m.
 sălictŏr=sălīctŏr|miles|sălīctōr||ōris, m.
 sălictum=sălīctum|templum|||i, n.
-sălĭens=sălĭēns|ciuis|sălĭēnt||entis, 
+sălĭens=sălĭēns|ciuis|sălĭēnt||entis,
 sălĭentes=sălĭēntes|ciuis|sălĭēnt||ium, m.
 sălĭfŏdīna|uita|||ae, f.
 sălignĕus=sălīgnĕus|aureus|||a, um
@@ -48984,7 +48984,7 @@ segmentum=sēgmēntum|templum|||i, n.
 sēgnē|adv|||adv.
 segnesco=sēgnēsco|lego|||ĕre, intr.
 Segni=Sēgni|liberi|||orum, m.
-segnĭpēs=sēgnĭpēs|miles|sēgnĭpĕd||ĕdis, 
+segnĭpēs=sēgnĭpēs|miles|sēgnĭpĕd||ĕdis,
 segnĭtās=sēgnĭtās|miles|sēgnĭtāt||ātis, f.
 segnĭtĭēs=sēgnĭtĭēs|res|||ei, f.
 Sēgō̆brīga|uita|||ae, f.
@@ -49257,7 +49257,7 @@ sēmĭsermo=sēmĭsērmo|miles|sēmĭsērmōn||ōnis, m.
 sēmĭsiccus=sēmĭsīccus|doctus|||a, um
 sēmĭsĭcĭlĭcus|lupus|||i, m.
 sēmĭsomnis=sēmĭsōmnis|fortis|sēmĭsōmn||e
-sēmĭsŏnans=sēmĭsŏnāns|ciuis|sēmĭsŏnānt||antis, 
+sēmĭsŏnans=sēmĭsŏnāns|ciuis|sēmĭsŏnānt||antis,
 sēmĭsŏnus|doctus|||a, um
 sēmĭsōpītus|doctus|||a, um
 sēmĭsŏpōrus|doctus|||a, um
@@ -49543,7 +49543,7 @@ sĕquestro=sĕqụēstro|amo|||āvi, ātum, 1
 sĕquĭŭs=sĕqụĭŭs|adv|||adv.
 sĕquo=sĕqụo|lego|||ĕre
 sĕquūtor=sĕqụūtŏr|miles|sĕqụūtōr||ōris, m.
-Sēr|miles|Sēr||ēris, 
+Sēr|miles|Sēr||ēris,
 sēra2|uita|||ae, f.
 Sera3|uita|||ae, f.
 sēră4|adv|||adv.
@@ -49614,7 +49614,7 @@ serpentārĭa=sērpēntārĭa|uita|||ae, f.
 serpentĭfōrmis=sērpēntĭfōrmis|fortis|sērpēntĭfōrm||e
 serpentĭgĕna=sērpēntĭgĕna|uita|||ae, f.
 serpentīnus=sērpēntīnus|doctus|||a, um
-serpentĭpēs=sērpēntĭpēs|miles|sērpēntĭpĕd||ĕdis, 
+serpentĭpēs=sērpēntĭpēs|miles|sērpēntĭpĕd||ĕdis,
 serpĕrastra=sērpĕrāstra|templum|||orum, n.
 serpillum=sērpīllum|templum|||i, n.
 serpĭo=sērpĭo|capio|||ĕre
@@ -50020,7 +50020,7 @@ Silbĭum=Sīlbĭum|templum|||ii, n.
 sĭlenda=sĭlēnda|templum|||orum, n.
 Sīlēnē|cybele|||es, f.
 Sīlēnĭcus|doctus|||a, um
-sĭlens=sĭlēns|ciuis|sĭlēnt||entis, 
+sĭlens=sĭlēns|ciuis|sĭlēnt||entis,
 sĭlentĕr=sĭlēntĕr|adv|||adv.
 sĭlentĭārĭus=sĭlēntĭārĭus|filius|||ii, m.
 sĭlentĭōsē=sĭlēntĭōsē|adv|||adv.
@@ -50135,7 +50135,7 @@ simpŭlārĭārĭus=sīmpŭlārĭārĭus|filius|||ii, m.
 simpŭlātŏr=sīmpŭlātŏr|miles|sīmpŭlātōr||ōris, m.
 simpŭlātrix=sīmpŭlātrīx|miles|sīmpŭlātrīc||īcis, f.
 simpŭlum=sīmpŭlum|templum|||i, n.
-simpŭvĭātrīx=sīmpŭvĭātrīx|miles|sīmpŭvĭātrīc||īcis, 
+simpŭvĭātrīx=sīmpŭvĭātrīx|miles|sīmpŭvĭātrīc||īcis,
 simpŭvĭum=sīmpŭvĭum|templum|||ii, n.
 sĭmŭlāmen|corpus|sĭmŭlāmĭn||ĭnĭs, n.
 sĭmŭlāmentum=sĭmŭlāmēntum|templum|||i, n.
@@ -55853,7 +55853,7 @@ Trĭnūmus|lupus|||i, m.
 trĭnundĭnum=trĭnūndĭnum|templum|||i, n.
 trĭnundĭnus=trĭnūndĭnus|doctus|||a, um
 trīnus|doctus|||a, um
-trĭo2|miles|trĭōn||ōnis, 
+trĭo2|miles|trĭōn||ōnis,
 trĭŏbŏlus|lupus|||i, m.
 Trĭobris=Trĭō̆bris|ciuis|Trĭō̆br||is, m.
 Trĭōcăla|templum|||orum, n.

--- a/bin/data/lem_ext.la
+++ b/bin/data/lem_ext.la
@@ -59229,7 +59229,6 @@ Alisales|ciuis|Alisal||ium, m.
 Ālĭus3|lupus|||i, m.
 allā̆crўmo=āllā̆crўmo|amo|||āre
 Allava=Āllava|roma|||ae, m.
-allēlūja2=āllēlūja|adv|||interj.
 Allīfāna=Āllīfāna|templum|||orum, n.
 Allīfāni=Āllīfāni|liberi|||orum, m.
 Allīfē=Āllīfē|cybele|||es, f.

--- a/bin/data/lem_ext.uk
+++ b/bin/data/lem_ext.uk
@@ -1546,7 +1546,7 @@ allegoria:an allegory, a figurative representation of a thought, of an abstract 
 allegorice:allegorically
 allegoricus:allegorical, Adv.
 allegorizo:to allegorize, to speak in allegories
-alleluia:praised be God! praise the Lord!
+alleluja:praised be God! praise the Lord!
 allenimentum:a soothing remedy
 allex2:the great toe;
 Allia:a little river eleven miles northwards from Rome, near Crustumerium, in the country of the Sabines
@@ -16689,7 +16689,6 @@ haliphloeos:a species of oak
 halipleumon:a kind of fish
 halito:to breathe out
 halitus:breath, exhalation, steam, vapor.
-hallelujah:praised be God! praise the Lord!
 hallex2:the great toe; hence, in derision, of a little man
 hallucinatio:a wandering of mind, dreaminess, revery
 hallucinator:one who is wandering in mind, a dreamer, a silly fellow
@@ -16785,7 +16784,6 @@ hauddum:an intensive nondum, not at all as yet
 hauritorium:a bucket
 haustor:a drawer, water-drawer, he who fills casks with wine
 haustrum:a machine for drawing water
-haustus2:⋯㊴⋳?Ă耀
 haveo:to be, fare well
 Heautontimorumenos:The Self-tormentor
 hebdomada:the number seven, seven days


### PR DESCRIPTION
Voilà un essai pour avoir une réponse correcte à alleluia (#25), mais il y a encore un problème que je ne comprend pas, dans l'onglet Lexique j'ai encore:

```
*  alleluia
  - āllēlūjă, interj. : du mot hébreu הַלְּלוּיָהּ signifiant / louez Dieu
  - āllēlūja, interj. : 
```

et dans scansion:

```
alˌleˌlúˌja (alˌléˌluja)
```

je n'arrive pas à comprendre où il va chercher la version sans longueur sur le a, elle n'est nulle part dans le lexique... une idée ?
