### PR TITLE
Modèle dies

### DIFF
--- a/bin/data/lemmes.la
+++ b/bin/data/lemmes.la
@@ -6700,7 +6700,8 @@ dĭēcŭla|uita|||ae, f.|1
 dĭēquinti=dĭēquīnti|inv|||adv.|2
 diērectus=dĭērēctus|doctus|||a, um|4
 Dĭespĭter=Dĭēspĭtĕr|miles|Dĭēspī̆tr||tris, m.|5
-dĭes|res|||ei, m. et f.|2928
+!dĭes|res|||ei, m. et f.|2928
+dĭes|dies|||ei, m. et f.|2928
 diffāmo=dīffāmo|amo|||as, are|4
 diffĕrentĭa=dīffĕrēntĭa|uita|||ae, f.|12
 diffĕrĭtās=dīffĕrĭtās|miles|dīffĕrĭtāt||ātis, f.|2

--- a/bin/data/modeles.la
+++ b/bin/data/modeles.la
@@ -283,6 +283,10 @@ modele:res
 R:1:2,0
 des:1-12:1:ēs;ēs;ĕm;ĕī;ĕī;ē;ēs;ēs;ēs;ērŭm;ēbŭs;ēbŭs
 
+modele:dies
+R:1:2,0
+des:1-12:1:ēs;ēs;ĕm;ēī;ēī;ē;ēs;ēs;ēs;ērŭm;ēbŭs;ēbŭs
+
 modele:abraham
 R:0:0,0
 R:1:2,0


### PR DESCRIPTION
Bonjour Philippe,

Je pense avoir trouvé une erreur au niveau du mot "dies", qui d'après Pede certo (si j'ai bien compris), devrait faire diēi au génitif et au datif. En latin ecclésiastique, je l'ai en effet toujours vu accentué diéi. Je me suis donc permis de créer un nouveau modèle "dies", et de l'attribuer au mot "dies" dans le fichier lemmes.la.
Peut-être serait-il plus élégant de donner "res" pour père à ce nouveau modèle ? Dans cette éventualité, pouvez-vous m'expliquer le fonctionnement des "filiations" ?

Bonne journée !
Fr. Romain Marie